### PR TITLE
Change header text color from gray to red

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -177,7 +177,7 @@ const Index = () => {
       <div className="max-w-6xl mx-auto px-6 py-8">
         {/* Header */}
         <header className="mb-12">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">MultiSelect</h1>
+          <h1 className="text-4xl font-bold text-red-500 mb-4">MultiSelect</h1>
           <p className="text-xl text-gray-600 mb-6">
             This input will initially only support the Tags input in the side
             panel of OneView V2. But it should be built with the intention of


### PR DESCRIPTION
Updates the MultiSelect header text color styling from `text-gray-900` to `text-red-500`.

This changes the main heading color from dark gray to red in the Index component.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/640afd72e8eb48b29f1287430d136e5d/spark-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>640afd72e8eb48b29f1287430d136e5d</projectId>-->
<!--<branchName>spark-home</branchName>-->