### PR TITLE
Update homepage URL and add asset routing to Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oneview-react-multiselect-docs",
   "private": true,
   "description": "Interactive documentation for oneview-react-multiselect NPM package",
-  "homepage": "https://YOUR_DEPLOYED_URL_HERE",
+  "homepage": "https://oneview-react-multiselect-docs.vercel.app",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,14 @@
   ],
   "routes": [
     {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
+      "src": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot))",
+      "dest": "/$1"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }


### PR DESCRIPTION
Updates the package.json homepage URL from placeholder to the actual Vercel deployment URL.

Adds new routing rules to vercel.json:
- Direct routing for assets in /assets/ directory
- Static file routing for common web assets (js, css, images, fonts)
- Maintains existing catch-all route for SPA functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/640afd72e8eb48b29f1287430d136e5d/vibe-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>640afd72e8eb48b29f1287430d136e5d</projectId>-->
<!--<branchName>vibe-field</branchName>-->