### PR TITLE
Bump version to 3.0.1 and add default export

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oneview-react-multiselect-component",
-  "version": "1.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oneview-react-multiselect-component",
-      "version": "1.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@radix-ui/react-popover": "^1.1.1",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oneview-react-multiselect-component",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Modern React MultiSelect component with tags, search, and custom templates for OneView V2",
   "keywords": [
     "react",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,3 +1,6 @@
+// Import the main component first
+import { MultiSelect } from "./components/MultiSelect";
+
 // Main MultiSelect component exports
 export { MultiSelect } from "./components/MultiSelect";
 export { Tag } from "./components/Tag";
@@ -21,3 +24,6 @@ export type { TagProps } from "./components/Tag";
 // Utility exports
 export { cn } from "./lib/utils";
 export { tagVariants } from "./components/Tag";
+
+// Default export for Figma Make compatibility
+export default MultiSelect;


### PR DESCRIPTION
Updates package version from 3.0.0 to 3.0.1 in package.json and synchronizes package-lock.json version from 1.0.0 to 3.0.1.

Adds default export for MultiSelect component in index.ts with comment indicating Figma Make compatibility. Also adds import statement for MultiSelect at the top of the file.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/640afd72e8eb48b29f1287430d136e5d/pixel-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>640afd72e8eb48b29f1287430d136e5d</projectId>-->
<!--<branchName>pixel-haven</branchName>-->